### PR TITLE
removal of Bio.Alphabet usage

### DIFF
--- a/analib/seq.py
+++ b/analib/seq.py
@@ -8,7 +8,6 @@ import pandas as pd
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Data import IUPACData
 
 
 def bed_to_seqrecord_iter(df, skip_na=True):
@@ -30,7 +29,7 @@ def bed_to_seqrecord_iter(df, skip_na=True):
             continue
 
         yield SeqRecord(
-            Seq(row['SEQ'], IUPACData.unambiguous_dna_letters),
+            Seq(row['SEQ']),
             id=row['ID'],
             description=''
         )

--- a/analib/seq.py
+++ b/analib/seq.py
@@ -8,7 +8,7 @@ import pandas as pd
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import IUPAC
+from Bio.Data import IUPACData
 
 
 def bed_to_seqrecord_iter(df, skip_na=True):
@@ -30,7 +30,7 @@ def bed_to_seqrecord_iter(df, skip_na=True):
             continue
 
         yield SeqRecord(
-            Seq(row['SEQ'], IUPAC.unambiguous_dna),
+            Seq(row['SEQ'], IUPACData.unambiguous_dna_letters),
             id=row['ID'],
             description=''
         )


### PR DESCRIPTION
Hi,

Thanks for providing this useful software. I tried to run `svpop` with BioPython v1.78 and noticed that `Bio.Alphabet` had been deprecated ([BioPython documentation for the replacement](https://biopython.org/wiki/Alphabet)). Therefore, I did slight edits to `analib/seq.py`, which I believed to be the only script explicitly using `Bio.Alphabet`. I wonder if you could take a look at this pull request.

Thanks!